### PR TITLE
added limit option

### DIFF
--- a/autolink.coffee
+++ b/autolink.coffee
@@ -3,9 +3,11 @@ autoLink = (options...) ->
     /(\b(https?):\/\/[\-A-Z0-9+&@#\/%?=~_|!:,.;]*[\-A-Z0-9+&@#\/%=~_|])/ig
 
   if options.length > 0
-    if options[0].limit
-      limit = options[0].limit
-      delete options[0].limit
+    omission = options[0].omission || '...'
+    delete options[0].omission
+
+    limit = options[0].limit
+    delete options[0].limit
 
     link_attributes = ''
 
@@ -17,7 +19,7 @@ autoLink = (options...) ->
       if limit
         displayUrl = displayUrl.replace /https?:\/{2}/, ''
         if displayUrl.length > limit
-          displayUrl = "#{displayUrl.substr(0, limit)}..."
+          displayUrl = "#{displayUrl.substr(0, limit - omission.length)}#{omission}"
 
       "<a href='#{url}'#{link_attributes}>#{displayUrl}</a>"
 

--- a/autolink.js
+++ b/autolink.js
@@ -4,14 +4,14 @@
     __slice = [].slice;
 
   autoLink = function() {
-    var key, limit, link_attributes, options, url_pattern, value, _ref;
+    var key, limit, link_attributes, omission, options, url_pattern, value, _ref;
     options = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
     url_pattern = /(\b(https?):\/\/[\-A-Z0-9+&@#\/%?=~_|!:,.;]*[\-A-Z0-9+&@#\/%=~_|])/ig;
     if (options.length > 0) {
-      if (options[0].limit) {
-        limit = options[0].limit;
-        delete options[0].limit;
-      }
+      omission = options[0].omission || '...';
+      delete options[0].omission;
+      limit = options[0].limit;
+      delete options[0].limit;
       link_attributes = '';
       _ref = options[0];
       for (key in _ref) {
@@ -24,7 +24,7 @@
         if (limit) {
           displayUrl = displayUrl.replace(/https?:\/{2}/, '');
           if (displayUrl.length > limit) {
-            displayUrl = "" + (displayUrl.substr(0, limit)) + "...";
+            displayUrl = "" + (displayUrl.substr(0, limit - omission.length)) + omission;
           }
         }
         return "<a href='" + url + "'" + link_attributes + ">" + displayUrl + "</a>";

--- a/test/autolink-spec.coffee
+++ b/test/autolink-spec.coffee
@@ -67,12 +67,12 @@ describe "autolink", ->
         "google.com</a>"
       )
 
-    it "truncates link if link is longer than limit", ->
+    it "truncates link if link is longer than limit - omission", ->
       expect(
         "Google it: http://google.com/derp/derp/derpderp/derp".autoLink(limit: 30)
       ).toEqual(
         "Google it: <a href='http://google.com/derp/derp/derpderp/derp'>" +
-        "google.com/derp/derp/derpderp/...</a>"
+        "google.com/derp/derp/derpde...</a>"
       )
 
     it "does not truncate link if link shorter than limit", ->
@@ -88,4 +88,17 @@ describe "autolink", ->
       .toEqual(
         "Google it: <a href='http://google.com/derp/derpderp/derpd'>" +
         "google.com/derp/derpderp/derpd</a>"
+      )
+
+
+  describe "omission option", ->
+    it "truncates link if link is longer than limit - omission and appends omission end", ->
+      expect(
+        "Google it: http://google.com/derp/derp/derpderp/derp".autoLink(
+          limit: 30
+          omission: '***'
+        )
+      ).toEqual(
+        "Google it: <a href='http://google.com/derp/derp/derpderp/derp'>" +
+        "google.com/derp/derp/derpde***</a>"
       )

--- a/test/autolink-spec.js
+++ b/test/autolink-spec.js
@@ -37,16 +37,16 @@
         rel: "nofollow"
       })).toEqual("Google it: <a href='http://google.com' target='_blank' " + "rel='nofollow'>http://google.com</a>");
     });
-    return describe("limit option", function() {
+    describe("limit option", function() {
       it("removes http", function() {
         return expect("Google it: http://google.com".autoLink({
           limit: 30
         })).toEqual("Google it: <a href='http://google.com'>" + "google.com</a>");
       });
-      it("truncates link if link is longer than limit", function() {
+      it("truncates link if link is longer than limit - omission", function() {
         return expect("Google it: http://google.com/derp/derp/derpderp/derp".autoLink({
           limit: 30
-        })).toEqual("Google it: <a href='http://google.com/derp/derp/derpderp/derp'>" + "google.com/derp/derp/derpderp/...</a>");
+        })).toEqual("Google it: <a href='http://google.com/derp/derp/derpderp/derp'>" + "google.com/derp/derp/derpde...</a>");
       });
       it("does not truncate link if link shorter than limit", function() {
         return expect("Google it: http://google.com".autoLink({
@@ -57,6 +57,14 @@
         return expect("Google it: http://google.com/derp/derpderp/derpd".autoLink({
           limit: 30
         })).toEqual("Google it: <a href='http://google.com/derp/derpderp/derpd'>" + "google.com/derp/derpderp/derpd</a>");
+      });
+    });
+    return describe("omission option", function() {
+      return it("truncates link if link is longer than limit - omission and appends omission end", function() {
+        return expect("Google it: http://google.com/derp/derp/derpderp/derp".autoLink({
+          limit: 30,
+          omission: '***'
+        })).toEqual("Google it: <a href='http://google.com/derp/derp/derpderp/derp'>" + "google.com/derp/derp/derpde***</a>");
       });
     });
   });


### PR DESCRIPTION
Adds limit option to be able to truncate the display link text. It also removes http:// and https:// from the display link text.

Ex:
`"Google it: http://google.com/derp/derp/derpderp/derp".autoLink({limit: 30}))`
will produce
`"Google it: <a href='http://google.com/derp/derp/derpderp/derp'>google.com/derp/derp/derpderp/...</a>"`
