### PR TITLE
Fix bower to exclude files correctly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "test"
   ],
   "main": [
-    "./autolink.js"
+    "./autolink-min.js"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   ],
   "license": "MIT",
   "ignore": [
-    "**/.*",
+    "*",
     "example",
     "test"
   ],


### PR DESCRIPTION
This PR changes the bower package to use autolink-min.js as it's main file, just like npm (right now the bower package has both the coffee script, javascript and the minified javascript files).