### PR TITLE
Corrected npm package name from autlink-js to autolink-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "autlink-js",
+  "name": "autolink-js",
   "version": "1.0.0",
   "description": "Tiny little tool to find URLs in a string of text and hyperlink them",
   "main": "autolink-min.js",


### PR DESCRIPTION
I just noticed a typo in the npm config.